### PR TITLE
Use sha256 checksum of gcc dll's to determine when to overwrite them

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ URIParser 0.0.3
 LibExpat 0.0.3
 Zlib 0.1.4
 BinDeps 0.3
+SHA

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,23 +1,47 @@
-using WinRPM
+using WinRPM, SHA
 WinRPM.update()
 
 # update julia's gcc dlls
 @windows_only begin
+    winrpm_bin = joinpath(WinRPM.installdir, "usr", Sys.MACHINE,
+        "sys-root", "mingw", "bin")
     dlls = ["libgfortran-3", "libquadmath-0", "libstdc++-6", "libssp-0",
         WORD_SIZE==32 ? "libgcc_s_sjlj-1" : "libgcc_s_seh-1"]
+    dlls_to_download = ASCIIString[]
+    for lib in dlls
+        if !isfile(joinpath(winrpm_bin, lib * ".dll"))
+            push!(dlls_to_download, replace(lib, "-", ""))
+        end
+        # try to clean up -copy remnants
+        if isfile(joinpath(JULIA_HOME, lib * "-copy.dll"))
+            try
+                rm(joinpath(JULIA_HOME, lib * "-copy.dll"))
+            end
+        end
+    end
+    if !isempty(dlls_to_download)
+        WinRPM.install(dlls_to_download; yes = true)
+    end
     dlls_to_update = ASCIIString[]
     for lib in dlls
-        if !isfile(joinpath(JULIA_HOME, lib * "-copy.dll"))
+        local sha_current, sha_new
+        open(joinpath(JULIA_HOME, lib * ".dll")) do f
+            sha_current = sha256(f)
+        end
+        open(joinpath(winrpm_bin, lib * ".dll")) do f
+            sha_new = sha256(f)
+        end
+        if sha_current != sha_new
             push!(dlls_to_update, lib)
         end
     end
     if !isempty(dlls_to_update)
         try
-            WinRPM.install(ASCIIString[replace(lib, "-", "") for lib in dlls_to_update]; yes = true)
             for lib in dlls_to_update
+                # it's possible to move an in-use dll and put a new file where
+                # it used to be, but not delete or overwrite it in-place?
                 mv(joinpath(JULIA_HOME, lib * ".dll"), joinpath(JULIA_HOME, lib * "-copy.dll"))
-                cp(joinpath(WinRPM.installdir, "usr", Sys.MACHINE, "sys-root", "mingw", "bin", lib * ".dll"),
-                    joinpath(JULIA_HOME, lib * ".dll"))
+                cp(joinpath(winrpm_bin, lib * ".dll"), joinpath(JULIA_HOME, lib * ".dll"))
             end
             warn("Updated Julia's gcc dlls, you may need to restart Julia for some WinRPM packages to work.")
         catch err


### PR DESCRIPTION
also attempt to clean up remnants of old updates, closes #41

@davidanthoff let me know if you have any feedback on this approach - it's still a little messier than I'd have liked since I can't figure out a way to delete the existing gcc dll's while they're in use by Julia.