### PR TITLE
@compat WinRPM.jl:204 for 0.3.11 compatibility

### DIFF
--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -201,7 +201,7 @@ getindex(pkg::Package,x) = getindex(pkg.pd,x)
 @compat immutable Packages{T<:Union{Set{ParsedData},Vector{ParsedData},}}
     p::T
 end
-Packages{T<:Union{Set{ParsedData},Vector{ParsedData}}}(pkgs::T) = Packages{T}(pkgs)
+@compat Packages{T<:Union{Set{ParsedData},Vector{ParsedData}}}(pkgs::T) = Packages{T}(pkgs)
 Packages(pkgs::Vector{Package}) = Packages([p.pd for p in pkgs])
 Packages(xpath::LibExpat.XPath) = Packages(packages[xpath])
 


### PR DESCRIPTION
On 0.4.0, there is absolutely no clutter anymore. So nice!
I got this on 0.3.11, however. No issue filed.
````
julia> Pkg.installed("WinRPM")
  "WinRPM"           => v"0.1.12+"
(..clutter clutter..)
ERROR: type: instantiate_type: expected TypeConstructor, got
 Function
 in include at boot.jl:245
 in include_from_node1 at loading.jl:128
 in reload_path at loading.jl:152
 in _require at loading.jl:67
 in require at loading.jl:51
while loading C:\Users\Fro\.julia\v0.3\WinRPM\src\WinRPM.jl,
 in expression starting on line 204
````