### PR TITLE
Fix Depwarns

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
-Compat 0.7.16
+Compat 0.7.20
 URIParser 0.0.3
 @unix HTTPClient 0.0.0
 LibExpat 0.0.3

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -74,7 +74,7 @@ elseif is_windows()
         return "", 0
     end
 else
-    error("Platform not supported: $(Sys.KERNEL)")
+    error("Platform not supported: $(Compat.KERNEL)")
 end
 
 getcachedir(source) = getcachedir(cachedir, source)

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -4,7 +4,7 @@ using Compat
 import Compat.String
 
 if is_unix()
-  using HTTPClient.HTTPC
+    using HTTPClient.HTTPC
 end
 
 using Zlib
@@ -49,32 +49,32 @@ function __init__()
 end
 
 if is_unix()
-  function download(source::AbstractString)
-    x = HTTPC.get(source)
-    unsafe_string(x.body), x.http_code
-  end
-elseif is_windows()
-  function download(source::AbstractString; retry = 5)
-    dest = Array(UInt16,261)
-    for i in 1:retry
-        res = ccall((:URLDownloadToCacheFileW,:urlmon),stdcall,Cuint,
-          (Ptr{Void},Ptr{UInt16},Ptr{UInt16},Clong,Cint,Ptr{Void}),
-          C_NULL,utf16(source),dest,sizeof(dest)>>1,0,C_NULL)
-        if res == 0
-            resize!(dest, findfirst(dest, 0))
-            filename = LegacyStrings.utf8(UTF16String(dest))
-            if isfile(filename)
-                return readstring(filename),200
-            end
-        else
-            warn("Unknown download failure, error code: $res")
-        end
-        warn("Retry $i/$retry downloading: $source")
+    function download(source::AbstractString)
+        x = HTTPC.get(source)
+        unsafe_string(x.body), x.http_code
     end
-    return "",0
-  end
+elseif is_windows()
+    function download(source::AbstractString; retry = 5)
+        dest = Array(UInt16,261)
+        for i in 1:retry
+            res = ccall((:URLDownloadToCacheFileW,:urlmon),stdcall,Cuint,
+              (Ptr{Void},Ptr{UInt16},Ptr{UInt16},Clong,Cint,Ptr{Void}),
+              C_NULL,utf16(source),dest,sizeof(dest)>>1,0,C_NULL)
+            if res == 0
+                resize!(dest, findfirst(dest, 0))
+                filename = LegacyStrings.utf8(UTF16String(dest))
+                if isfile(filename)
+                    return readstring(filename),200
+                end
+            else
+                warn("Unknown download failure, error code: $res")
+            end
+            warn("Retry $i/$retry downloading: $source")
+        end
+        return "", 0
+    end
 else
-  error("Platform not supported: $(Sys.KERNEL)")
+    error("Platform not supported: $(Sys.KERNEL)")
 end
 
 getcachedir(source) = getcachedir(cachedir, source)
@@ -476,9 +476,9 @@ function do_install(package::Package)
             err = pc
             if is_unix()
                 cd(installdir) do
-                  if success(`rpm2cpio $path2` | `cpio -imud`)
-                      err = nothing
-                  end
+                    if success(`rpm2cpio $path2` | `cpio -imud`)
+                        err = nothing
+                    end
               end
             end
             isfile(cpio) && rm(cpio)

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -479,7 +479,7 @@ function do_install(package::Package)
                     if success(`rpm2cpio $path2` | `cpio -imud`)
                         err = nothing
                     end
-              end
+                end
             end
             isfile(cpio) && rm(cpio)
             err !== nothing && pipeline_error(err)

--- a/src/winrpm_bindeps.jl
+++ b/src/winrpm_bindeps.jl
@@ -6,19 +6,19 @@ import BinDeps: PackageManager, can_use, package_available, available_version,
 
 update_once = true
 
-type RPM <: PackageManager 
+type RPM <: PackageManager
     package
 end
 
 can_use(::Type{RPM}) = OS_NAME == :Windows
-function package_available(p::RPM) 
+function package_available(p::RPM)
     global update_once::Bool
-    !can_use(RPM) && return false    
+    !can_use(RPM) && return false
     pkgs = p.package
     if isa(pkgs,AbstractString)
         pkgs = [pkgs]
     end
-    if (update_once::Bool) 
+    if (update_once::Bool)
         info("Updating WinRPM package list")
         update(); update_once = false;
     end
@@ -33,8 +33,8 @@ provider(::Type{RPM},packages::Vector{Compat.ASCIIString}; opts...) = RPM(packag
 provides(::Type{RPM},packages::AbstractArray, dep::LibraryDependency; opts...) =
     provides(provider(RPM, packages; opts...), dep; opts...)
 
-function generate_steps(dep::LibraryDependency,h::RPM,opts) 
-    if get(opts,:force_rebuild,false) 
+function generate_steps(dep::LibraryDependency,h::RPM,opts)
+    if get(opts,:force_rebuild,false)
         error("Will not force WinRPM to rebuild dependency \"$(dep.name)\".\n"*
               "Please make any necessary adjustments manually (This might just be a version upgrade)")
     end


### PR DESCRIPTION
I just tried using WinRPM on 0.4, not sure if that's a sufficient test... Actually, the depwarns are so bad, that WinRPM just stops installing binaries without any error. So this also needs the depwarn removal from LibExpat (amitmurthy/LibExpat.jl#45)