### PR TITLE
Use LegacyStrings to fix breakage on 0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
-Compat
+Compat 0.7.16
 URIParser 0.0.3
 @unix HTTPClient 0.0.0
 LibExpat 0.0.3

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4
 Compat
 URIParser 0.0.3
 @unix HTTPClient 0.0.0
@@ -6,3 +6,4 @@ LibExpat 0.0.3
 Zlib 0.1.4
 BinDeps 0.3
 SHA
+LegacyStrings

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -5,6 +5,7 @@ using Compat
 using Zlib
 using LibExpat
 using URIParser
+using LegacyStrings
 
 import Base: show, getindex, wait_close, pipeline_error
 

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -51,7 +51,7 @@ end
           C_NULL,utf16(source),dest,sizeof(dest)>>1,0,C_NULL)
         if res == 0
             resize!(dest, findfirst(dest, 0))
-            filename = utf8(UTF16String(dest))
+            filename = LegacyStrings.utf8(UTF16String(dest))
             if isfile(filename)
                 return readall(filename),200
             end

--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -121,7 +121,7 @@ function update(ignorecache::Bool=false, allow_remote::Bool=true)
             continue
         end
         cache = getcachedir(source)
-        function cacheget(path::ASCIIString, never_cache::Bool)
+        function cacheget(path::Compat.ASCIIString, never_cache::Bool)
             gunzip = false
             path2 = joinpath(cache,escape(path))
             if endswith(path2, ".gz")
@@ -350,7 +350,7 @@ end
 
 install(pkg::AbstractString, arch::AbstractString=OS_ARCH; yes = false) = install(select(lookup(pkg, arch),pkg); yes = yes)
 
-function install(pkgs::Vector{ASCIIString}, arch = OS_ARCH; yes = false)
+function install(pkgs::Vector{Compat.ASCIIString}, arch = OS_ARCH; yes = false)
     todo = Package[]
     for pkg in pkgs
         push!(todo,select(lookup(pkg, arch),pkg))

--- a/src/winrpm_bindeps.jl
+++ b/src/winrpm_bindeps.jl
@@ -29,7 +29,7 @@ available_version(p::RPM) = lookup(p.package).p[1][xpath"version/@ver"][1]
 libdir(p::RPM,dep) = joinpath(dirname(dirname(@__FILE__)),"deps","usr","$(Sys.ARCH)-w64-mingw32","sys-root","mingw","bin")
 pkg_name(p::RPM) = p.package
 
-provider(::Type{RPM},packages::Vector{ASCIIString}; opts...) = RPM(packages)
+provider(::Type{RPM},packages::Vector{Compat.ASCIIString}; opts...) = RPM(packages)
 provides(::Type{RPM},packages::AbstractArray, dep::LibraryDependency; opts...) =
     provides(provider(RPM, packages; opts...), dep; opts...)
 


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/WinRPM.jl/issues/78

Requires dropping 0.3 support (or implementing it in LegacyStrings, though probably not worth it). This is probably a package worth making a branch, and METADATA test exceptions, for once we (otherwise) freeze METADATA for Julia 0.3.

I don't have time to set up AppVeyor here right now, but I will test this indirectly via a branch of LightXML.